### PR TITLE
Consistently use global paths in `Decode`

### DIFF
--- a/starknet-rust-core-derive/src/lib.rs
+++ b/starknet-rust-core-derive/src/lib.rs
@@ -308,7 +308,7 @@ pub fn derive_decode(input: TokenStream) -> TokenStream {
         impl<'a> #core::codec::Decode<'a> for #ident {
             fn decode_iter<T>(iter: &mut T) -> ::core::result::Result<Self, #core::codec::Error>
             where
-                T: core::iter::Iterator<Item = &'a #core::types::Felt>
+                T: ::core::iter::Iterator<Item = &'a #core::types::Felt>
             {
                 #impl_block
             }


### PR DESCRIPTION
From xJonathanLEI/starknet-rs#779

---

**Stack**:
- #48 ⬅
- #47
- #46


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*