### PR TITLE
Add conversion traits between Felt and StorageKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Upgraded `starknet-types-core` from `0.2.4` to `1.0.0` ([#129]).
+- Added `From<Felt>` and `TryFrom<&StorageKey>` conversion traits for `StorageKey` ([#130]).
 
 ## [0.19.0-rc.2] - 2026-03-23
 
@@ -49,3 +50,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#120]: https://github.com/software-mansion/starknet-rust/pull/120
 [#125]: https://github.com/software-mansion/starknet-rust/pull/125
 [#129]: https://github.com/software-mansion/starknet-rust/pull/129
+[#130]: https://github.com/software-mansion/starknet-rust/pull/130

--- a/starknet-rust-core/src/types/mod.rs
+++ b/starknet-rust-core/src/types/mod.rs
@@ -971,6 +971,20 @@ impl TryFrom<&L1HandlerTransaction> for MsgToL2 {
     }
 }
 
+impl From<Felt> for StorageKey {
+    fn from(felt: Felt) -> Self {
+        Self(alloc::format!("{felt:#x}"))
+    }
+}
+
+impl TryFrom<&StorageKey> for Felt {
+    type Error = starknet_types_core::felt::FromStrError;
+
+    fn try_from(key: &StorageKey) -> Result<Self, Self::Error> {
+        Self::from_hex(&key.0)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{requests::*, *};
@@ -1511,5 +1525,25 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_storage_key_from_felt() {
+        let felt = Felt::from_hex("0x1e240").unwrap();
+        let key = StorageKey::from(felt);
+        assert_eq!(key.0, "0x1e240");
+    }
+
+    #[test]
+    fn test_felt_try_from_storage_key() {
+        let key = StorageKey("0x1e240".to_string());
+        let felt = Felt::try_from(&key).unwrap();
+        assert_eq!(felt, Felt::from_hex("0x1e240").unwrap());
+    }
+
+    #[test]
+    fn test_felt_try_from_storage_key_invalid() {
+        let key = StorageKey("not_hex".to_string());
+        assert!(Felt::try_from(&key).is_err());
     }
 }


### PR DESCRIPTION
## Summary
- Add `From<Felt> for StorageKey` — formats as `0x`-prefixed lowercase hex
- Add `TryFrom<&StorageKey> for Felt` — parses the hex string back into a `Felt`

Depends on #129 (starknet-types-core 1.0.0 upgrade).

## Test plan
- [x] `test_storage_key_from_felt` — round-trip from Felt to StorageKey
- [x] `test_felt_try_from_storage_key` — round-trip from StorageKey to Felt
- [x] `test_felt_try_from_storage_key_invalid` — invalid hex returns error
- [x] clippy clean

🤖 Generated with [Claude Code](https://claude.ai/code)