### PR TITLE
Fix codec derive macros compilation error when dependant does not import `starknet-rust-core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1656,6 +1656,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "meta-package-consumer"
+version = "0.19.0"
+dependencies = [
+ "starknet-rust",
+]
+
+[[package]]
 name = "minicov"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2724,6 +2731,7 @@ dependencies = [
  "starknet-rust-accounts",
  "starknet-rust-contract",
  "starknet-rust-core",
+ "starknet-rust-core-derive",
  "starknet-rust-macros",
  "starknet-rust-providers",
  "starknet-rust-signers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "starknet-rust-tokio-tungstenite",
     "examples/starknet-rust-wasm",
     "examples/starknet-rust-cxx/starknet-rust-cxx",
+    "tests/meta-package-consumer",
     "utils/test-common",
 ]
 
@@ -111,6 +112,7 @@ all-features = true
 
 [dependencies]
 starknet-rust-core.workspace = true
+starknet-rust-core-derive = { workspace = true, features = ["import_from_starknet"] }
 starknet-rust-providers.workspace = true
 starknet-rust-contract.workspace = true
 starknet-rust-signers.workspace = true

--- a/tests/meta-package-consumer/Cargo.toml
+++ b/tests/meta-package-consumer/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "meta-package-consumer"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+starknet-rust = { path = "../.." }
+
+[lints]
+workspace = true

--- a/tests/meta-package-consumer/src/lib.rs
+++ b/tests/meta-package-consumer/src/lib.rs
@@ -1,0 +1,5 @@
+use starknet_rust::core::codec::{Decode, Encode};
+
+// Ensures that the import path used by the derive macros resolves in a package which only has access to the meta crate
+#[derive(Encode, Decode)]
+struct _Codec;


### PR DESCRIPTION
Regression introduced in 6e0cceaefd3e6c2e7703cf53c5339ed0b3635eda