### PR TITLE
Pin `ledger-app-dev-tools` version and bump rpc version test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -177,7 +177,7 @@ jobs:
   ledger:
     name: Ledger tests
     runs-on: ubuntu-latest
-    container: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools
+    container: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools:5.3.14
 
     steps:
       - name: Checkout source code
@@ -194,16 +194,13 @@ jobs:
           cache-on-failure: true
 
       - name: Clone app-starknet
-        run: |
-          git clone --depth 1 https://github.com/LedgerHQ/app-starknet.git /tmp/app-starknet
-          cd /tmp/app-starknet
-          git checkout a14a61e3061f8793188fa57cbdafc2cc0d96c8bd # v2.4.0
+        run: git clone --depth 1 --branch nanox_2.7.0_2.4.0_sdk_v26.0.2 https://github.com/LedgerHQ/app-starknet.git /tmp/app-starknet
 
       - name: Build Starknet Ledger App (Nano X)
         run: |
           cd /tmp/app-starknet/starknet
-          # RUST_NIGHTLY is set in the ledger-app-builder image
-          cargo +${RUST_NIGHTLY} ledger build nanox
+          # RUSTUP_TOOLCHAIN is set in the ledger-app-builder image
+          cargo +${RUSTUP_TOOLCHAIN} ledger build nanox
           mkdir -p ${GITHUB_WORKSPACE}/starknet-rust-signers/test-data/ledger-app
           mkdir -p ${GITHUB_WORKSPACE}/starknet-rust-accounts/test-data/ledger-app
           cp target/nanox/release/starknet \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2836,6 +2836,7 @@ dependencies = [
  "getrandom 0.2.16",
  "log",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "serde_with",

--- a/starknet-rust-accounts/tests/single_owner_account.rs
+++ b/starknet-rust-accounts/tests/single_owner_account.rs
@@ -257,7 +257,7 @@ async fn can_execute_eth_transfer_invoke_v3_with_manual_gas_inner<P: Provider + 
             .l1_gas(0)
             .l1_gas_price(1_000_000_000_000_000)
             .l2_gas(1_000_000)
-            .l2_gas_price(10_000_000_000)
+            .l2_gas_price(100_000_000_000)
             .l1_data_gas(1000)
             .l1_data_gas_price(1_000_000_000_000_000)
             // This tx costs around 10^6 L2 gas. So a tip of 10^10 is around 10^16 FRI (0.01 STRK).
@@ -363,7 +363,7 @@ async fn can_declare_cairo1_contract_v3_inner<P: Provider + Send + Sync>(
         .l1_gas(0)
         .l1_gas_price(1_000_000_000_000_000)
         .l2_gas(100_000_000)
-        .l2_gas_price(10_000_000_000)
+        .l2_gas_price(100_000_000_000)
         .l1_data_gas(1000)
         .l1_data_gas_price(1_000_000_000_000_000)
         .send()

--- a/starknet-rust-contract/tests/contract_deployment.rs
+++ b/starknet-rust-contract/tests/contract_deployment.rs
@@ -80,7 +80,7 @@ async fn can_deploy_contract_inner(account_address: Felt, udc: UdcSelector, uniq
         .l1_gas(0)
         .l1_gas_price(1_000_000_000_000_000)
         .l2_gas(2_000_000)
-        .l2_gas_price(10_000_000_000)
+        .l2_gas_price(100_000_000_000)
         .l1_data_gas(1000)
         .l1_data_gas_price(1_000_000_000_000_000);
     let deployed_address = deployment.deployed_address();

--- a/starknet-rust-providers/Cargo.toml
+++ b/starknet-rust-providers/Cargo.toml
@@ -34,6 +34,7 @@ getrandom = { workspace = true, features = ["js"] }
 starknet-rust-providers = { path = ".", features = ["no_unknown_fields"] }
 tokio = { workspace = true, features = ["full"] }
 test-common.workspace = true
+semver = { workspace = true, features = ["std"] }
 
 [features]
 default = ["std"]

--- a/starknet-rust-providers/tests/jsonrpc.rs
+++ b/starknet-rust-providers/tests/jsonrpc.rs
@@ -27,7 +27,7 @@ async fn jsonrpc_spec_version() {
     let parsed = Version::parse(&version).expect("spec_version is not valid semver");
     let core = Version::new(parsed.major, parsed.minor, parsed.patch);
     assert!(
-        VersionReq::parse("0.10.0").unwrap().matches(&core),
+        VersionReq::parse("0.10.3").unwrap().matches(&core),
         "Unexpected spec version: {version}"
     );
 }

--- a/starknet-rust-providers/tests/jsonrpc.rs
+++ b/starknet-rust-providers/tests/jsonrpc.rs
@@ -27,7 +27,7 @@ async fn jsonrpc_spec_version() {
     let parsed = Version::parse(&version).expect("spec_version is not valid semver");
     let core = Version::new(parsed.major, parsed.minor, parsed.patch);
     assert!(
-        VersionReq::parse("0.10.3").unwrap().matches(&core),
+        VersionReq::parse("0.10.2").unwrap().matches(&core),
         "Unexpected spec version: {version}"
     );
 }

--- a/starknet-rust-providers/tests/jsonrpc.rs
+++ b/starknet-rust-providers/tests/jsonrpc.rs
@@ -41,7 +41,12 @@ async fn jsonrpc_starknet_version() {
         .await
         .unwrap();
 
-    assert_eq!(version, "0.14.2");
+    let parsed = Version::parse(&version).expect("starknet_version is not valid semver");
+    let core = Version::new(parsed.major, parsed.minor, parsed.patch);
+    assert!(
+        VersionReq::parse("0.14.2").unwrap().matches(&core),
+        "Unexpected starknet version: {version}"
+    );
 }
 
 #[tokio::test]

--- a/starknet-rust-providers/tests/jsonrpc.rs
+++ b/starknet-rust-providers/tests/jsonrpc.rs
@@ -1,3 +1,4 @@
+use semver::{Version, VersionReq};
 use starknet_rust_core::{
     types::{
         BlockId, BlockTag, BroadcastedInvokeTransaction, BroadcastedInvokeTransactionV3,
@@ -21,9 +22,12 @@ async fn jsonrpc_spec_version() {
 
     let version = rpc_client.spec_version().await.unwrap();
 
-    // TODO(#139)
+    // Strip prerelease/build metadata so RC versions (e.g. "0.10.3-rc.0") match
+    // the same way as their stable counterpart.
+    let parsed = Version::parse(&version).expect("spec_version is not valid semver");
+    let core = Version::new(parsed.major, parsed.minor, parsed.patch);
     assert!(
-        version == "0.10.1" || version == "0.10.2",
+        VersionReq::parse("0.10.0").unwrap().matches(&core),
         "Unexpected spec version: {version}"
     );
 }

--- a/utils/speculos-client/src/lib.rs
+++ b/utils/speculos-client/src/lib.rs
@@ -342,9 +342,7 @@ fn events_api_ready(
     };
 
     http_response_ok(&response)
-        && serde_json::from_str::<Value>(body.trim())
-            .ok()
-            .is_some_and(|value| events_value_ready(&value))
+        && serde_json::from_str::<Value>(body.trim()).is_ok_and(|value| events_value_ready(&value))
 }
 
 fn http_response_ok(response: &str) -> bool {


### PR DESCRIPTION
Closes #139 

## Introduced changes

- There was change in `ledger-app-dev-tools`, I haven't pinned it before so it always use latest, to avoid similar situations in the future I add a pin to the version and fix it as well 

## Checklist

- [x] Linked relevant issue
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
