### PR TITLE
Remove redundant sequencer `BlockId` (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** Removed the redundant sequencer-specific `BlockId` in `starknet-rust-providers`; the sequencer gateway provider now uses the canonical `starknet_rust_core::types::BlockId` throughout ([#43]).
 - **Breaking:** `LegacyContractClass.abi` type changed from `Vec<RawLegacyAbiEntry>` to `Option<Vec<RawLegacyAbiEntry>>` to preserve the `abi: null` vs `abi: []` distinction when computing Cairo 0 hinted class hashes ([#148]).
 
 ### Fixed
@@ -82,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed `event_count` and `transaction_count` from `sequencer::models::Block` in `starknet-rust-providers`, as these fields are not part of sequencer gateway block responses ([#101])
 
+[#43]: https://github.com/software-mansion/starknet-rust/issues/43
 [#45]: https://github.com/software-mansion/starknet-rust/pull/45
 [#98]: https://github.com/software-mansion/starknet-rust/pull/98
 [#101]: https://github.com/software-mansion/starknet-rust/pull/101

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Breaking:** Removed the redundant sequencer-specific `BlockId` in `starknet-rust-providers`; the sequencer gateway provider now uses the canonical `starknet_rust_core::types::BlockId` throughout ([#43]).
+- **Breaking:** Removed the redundant sequencer-specific `BlockId` in `starknet-rust-providers`. The sequencer gateway provider now uses the canonical `starknet_rust_core::types::BlockId` throughout ([#154]).
 - **Breaking:** `LegacyContractClass.abi` type changed from `Vec<RawLegacyAbiEntry>` to `Option<Vec<RawLegacyAbiEntry>>` to preserve the `abi: null` vs `abi: []` distinction when computing Cairo 0 hinted class hashes ([#148]).
 
 ### Fixed
@@ -83,7 +83,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed `event_count` and `transaction_count` from `sequencer::models::Block` in `starknet-rust-providers`, as these fields are not part of sequencer gateway block responses ([#101])
 
-[#43]: https://github.com/software-mansion/starknet-rust/issues/43
 [#45]: https://github.com/software-mansion/starknet-rust/pull/45
 [#98]: https://github.com/software-mansion/starknet-rust/pull/98
 [#101]: https://github.com/software-mansion/starknet-rust/pull/101
@@ -91,3 +90,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#120]: https://github.com/software-mansion/starknet-rust/pull/120
 [#125]: https://github.com/software-mansion/starknet-rust/pull/125
 [#148]: https://github.com/software-mansion/starknet-rust/pull/148
+[#154]: https://github.com/software-mansion/starknet-rust/pull/154

--- a/starknet-rust-providers/src/sequencer/mod.rs
+++ b/starknet-rust-providers/src/sequencer/mod.rs
@@ -8,7 +8,7 @@ use serde_with::serde_as;
 use starknet_rust_core::{
     chain_id,
     serde::unsigned_field_element::UfeHex,
-    types::{Felt, StarknetError, contract::CompiledClass},
+    types::{BlockId, BlockTag, Felt, StarknetError, contract::CompiledClass},
 };
 use url::Url;
 
@@ -16,7 +16,7 @@ use url::Url;
 #[allow(unused)]
 pub mod models;
 use models::{
-    AddTransactionResult, Block, BlockId, ContractAddresses, DeployedClass, StateUpdate,
+    AddTransactionResult, Block, ContractAddresses, DeployedClass, StateUpdate,
     StateUpdateWithBlock, TransactionInfo, TransactionRequest, TransactionStatusInfo,
     conversions::ConversionError,
 };
@@ -279,7 +279,7 @@ impl SequencerGatewayProvider {
     )]
     pub async fn get_block(&self, block_identifier: BlockId) -> Result<Block, ProviderError> {
         let mut request_url = self.extend_feeder_gateway_url("get_block");
-        append_block_id(&mut request_url, block_identifier);
+        append_block_id(&mut request_url, block_identifier)?;
 
         self.send_get_request::<GatewayResponse<_>>(request_url)
             .await?
@@ -294,7 +294,7 @@ impl SequencerGatewayProvider {
         block_identifier: BlockId,
     ) -> Result<StateUpdate, ProviderError> {
         let mut request_url = self.extend_feeder_gateway_url("get_state_update");
-        append_block_id(&mut request_url, block_identifier);
+        append_block_id(&mut request_url, block_identifier)?;
 
         self.send_get_request::<GatewayResponse<_>>(request_url)
             .await?
@@ -309,7 +309,7 @@ impl SequencerGatewayProvider {
         block_identifier: BlockId,
     ) -> Result<StateUpdateWithBlock, ProviderError> {
         let mut request_url = self.extend_feeder_gateway_url("get_state_update");
-        append_block_id(&mut request_url, block_identifier);
+        append_block_id(&mut request_url, block_identifier)?;
         request_url
             .query_pairs_mut()
             .append_pair("includeBlock", "true");
@@ -331,7 +331,7 @@ impl SequencerGatewayProvider {
         request_url
             .query_pairs_mut()
             .append_pair("classHash", &format!("{class_hash:#x}"));
-        append_block_id(&mut request_url, block_identifier);
+        append_block_id(&mut request_url, block_identifier)?;
 
         self.send_get_request::<GatewayResponse<_>>(request_url)
             .await?
@@ -350,7 +350,7 @@ impl SequencerGatewayProvider {
         request_url
             .query_pairs_mut()
             .append_pair("classHash", &format!("{class_hash:#x}"));
-        append_block_id(&mut request_url, block_identifier);
+        append_block_id(&mut request_url, block_identifier)?;
 
         self.send_get_request::<GatewayResponse<_>>(request_url)
             .await?
@@ -529,7 +529,7 @@ fn extend_url(url: &mut Url, segment: &str) {
         .extend(&[segment]);
 }
 
-fn append_block_id(url: &mut Url, block_identifier: BlockId) {
+fn append_block_id(url: &mut Url, block_identifier: BlockId) -> Result<(), ConversionError> {
     match block_identifier {
         BlockId::Hash(block_hash) => {
             url.query_pairs_mut()
@@ -539,11 +539,14 @@ fn append_block_id(url: &mut Url, block_identifier: BlockId) {
             url.query_pairs_mut()
                 .append_pair("blockNumber", &block_number.to_string());
         }
-        BlockId::Pending => {
+        BlockId::Tag(BlockTag::PreConfirmed) => {
             url.query_pairs_mut().append_pair("blockNumber", "pending");
         }
-        BlockId::Latest => (), // latest block is implicit
+        BlockId::Tag(BlockTag::Latest) => (), // latest block is implicit
+        // The feeder gateway has no `l1_accepted` concept.
+        BlockId::Tag(BlockTag::L1Accepted) => return Err(ConversionError),
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/starknet-rust-providers/src/sequencer/models/block.rs
+++ b/starknet-rust-providers/src/sequencer/models/block.rs
@@ -7,14 +7,6 @@ use starknet_rust_core::{
 
 use super::{ConfirmedTransactionReceipt, TransactionType};
 
-#[derive(Debug, Clone, Copy)]
-pub enum BlockId {
-    Hash(Felt),
-    Number(u64),
-    Pending,
-    Latest,
-}
-
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]

--- a/starknet-rust-providers/src/sequencer/models/conversions.rs
+++ b/starknet-rust-providers/src/sequencer/models/conversions.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use starknet_rust_core::types::{self as core, Felt, contract::legacy as contract_legacy};
 
 use super::{
-    Block, BlockId, BlockStatus, CompressedLegacyContractClass, ConfirmedTransactionReceipt,
+    Block, BlockStatus, CompressedLegacyContractClass, ConfirmedTransactionReceipt,
     DeclareTransaction, DeclareTransactionRequest, DeclareV3TransactionRequest,
     DeployAccountTransaction, DeployAccountTransactionRequest, DeployAccountV3TransactionRequest,
     DeployTransaction, DeployedClass, EntryPointType, Event, InvokeFunctionTransaction,
@@ -23,20 +23,6 @@ pub struct ConfirmedReceiptWithContext {
     pub receipt: ConfirmedTransactionReceipt,
     pub transaction: TransactionType,
     pub finality: BlockStatus,
-}
-
-impl TryFrom<core::BlockId> for BlockId {
-    type Error = ConversionError;
-
-    fn try_from(value: core::BlockId) -> Result<Self, Self::Error> {
-        match value {
-            core::BlockId::Hash(hash) => Ok(Self::Hash(hash)),
-            core::BlockId::Number(num) => Ok(Self::Number(num)),
-            core::BlockId::Tag(core::BlockTag::Latest) => Ok(Self::Latest),
-            core::BlockId::Tag(core::BlockTag::PreConfirmed) => Ok(Self::Pending),
-            core::BlockId::Tag(core::BlockTag::L1Accepted) => Err(ConversionError),
-        }
-    }
 }
 
 impl TryFrom<Block> for core::MaybePreConfirmedBlockWithTxHashes {

--- a/starknet-rust-providers/src/sequencer/models/mod.rs
+++ b/starknet-rust-providers/src/sequencer/models/mod.rs
@@ -8,7 +8,7 @@ pub use ethereum_types::Address as L1Address;
 pub(crate) mod conversions;
 
 mod block;
-pub use block::{Block, BlockId, BlockStatus};
+pub use block::{Block, BlockStatus};
 
 mod transaction;
 pub use transaction::{

--- a/starknet-rust-providers/src/sequencer/provider.rs
+++ b/starknet-rust-providers/src/sequencer/provider.rs
@@ -4,7 +4,7 @@ use std::any::Any;
 
 use async_trait::async_trait;
 use starknet_rust_core::types::{
-    BlockHashAndNumber, BlockId, BroadcastedDeclareTransaction,
+    BlockHashAndNumber, BlockId, BlockTag, BroadcastedDeclareTransaction,
     BroadcastedDeployAccountTransaction, BroadcastedInvokeTransaction, BroadcastedTransaction,
     ConfirmedBlockId, ContractClass, ContractStorageKeys, DeclareTransactionResult,
     DeployAccountTransactionResult, EventFilter, EventsPage, FeeEstimate, Felt, FunctionCall,
@@ -52,7 +52,7 @@ impl Provider for SequencerGatewayProvider {
         B: AsRef<BlockId> + Send + Sync,
     {
         Ok(self
-            .get_block(block_id.as_ref().to_owned().try_into()?)
+            .get_block(block_id.as_ref().to_owned())
             .await?
             .try_into()?)
     }
@@ -66,7 +66,7 @@ impl Provider for SequencerGatewayProvider {
         B: AsRef<BlockId> + Send + Sync,
     {
         Ok(self
-            .get_block(block_id.as_ref().to_owned().try_into()?)
+            .get_block(block_id.as_ref().to_owned())
             .await?
             .try_into()?)
     }
@@ -80,7 +80,7 @@ impl Provider for SequencerGatewayProvider {
         B: AsRef<BlockId> + Send + Sync,
     {
         Ok(self
-            .get_block(block_id.as_ref().to_owned().try_into()?)
+            .get_block(block_id.as_ref().to_owned())
             .await?
             .try_into()?)
     }
@@ -93,7 +93,7 @@ impl Provider for SequencerGatewayProvider {
         B: AsRef<BlockId> + Send + Sync,
     {
         Ok(self
-            .get_state_update(block_id.as_ref().to_owned().try_into()?)
+            .get_state_update(block_id.as_ref().to_owned())
             .await?
             .try_into()?)
     }
@@ -176,9 +176,7 @@ impl Provider for SequencerGatewayProvider {
     where
         B: AsRef<BlockId> + Send + Sync,
     {
-        let mut block = self
-            .get_block(block_id.as_ref().to_owned().try_into()?)
-            .await?;
+        let mut block = self.get_block(block_id.as_ref().to_owned()).await?;
 
         let index = index as usize;
         if index < block.transactions.len() {
@@ -213,10 +211,7 @@ impl Provider for SequencerGatewayProvider {
         H: AsRef<Felt> + Send + Sync,
     {
         Ok(self
-            .get_class_by_hash(
-                *class_hash.as_ref(),
-                block_id.as_ref().to_owned().try_into()?,
-            )
+            .get_class_by_hash(*class_hash.as_ref(), block_id.as_ref().to_owned())
             .await?
             .try_into()?)
     }
@@ -255,9 +250,7 @@ impl Provider for SequencerGatewayProvider {
     where
         B: AsRef<BlockId> + Send + Sync,
     {
-        let block = self
-            .get_block(block_id.as_ref().to_owned().try_into()?)
-            .await?;
+        let block = self.get_block(block_id.as_ref().to_owned()).await?;
         Ok(block.transactions.len() as u64)
     }
 
@@ -305,12 +298,12 @@ impl Provider for SequencerGatewayProvider {
     }
 
     async fn block_number(&self) -> Result<u64, ProviderError> {
-        let block = self.get_block(super::models::BlockId::Latest).await?;
+        let block = self.get_block(BlockId::Tag(BlockTag::Latest)).await?;
         Ok(block.block_number.ok_or(ConversionError)?)
     }
 
     async fn block_hash_and_number(&self) -> Result<BlockHashAndNumber, ProviderError> {
-        let block = self.get_block(super::models::BlockId::Latest).await?;
+        let block = self.get_block(BlockId::Tag(BlockTag::Latest)).await?;
         Ok(BlockHashAndNumber {
             block_hash: block.block_hash.ok_or(ConversionError)?,
             block_number: block.block_number.ok_or(ConversionError)?,


### PR DESCRIPTION
Closes #43.

## Problem

There were two `BlockId` types in the codebase:

- The canonical `starknet_rust_core::types::BlockId` — `Hash(Felt)` / `Number(u64)` / `Tag(BlockTag)`, tracking the latest RPC block tags (`latest` / `pre_confirmed` / `l1_accepted`).
- A sequencer-specific `BlockId` in `starknet-rust-providers` — `Hash(Felt)` / `Number(u64)` / `Pending` / `Latest` — which was outdated and required a `TryFrom<core::BlockId>` conversion at every sequencer gateway call site.

## Change

Unify on the core `BlockId` throughout the sequencer gateway provider:

- Delete the sequencer-specific `BlockId` enum and its `TryFrom<core::BlockId>` conversion.
- `append_block_id` now takes the core `BlockId` directly and builds the feeder-gateway query, mapping:
  - `Tag(BlockTag::PreConfirmed)` → `blockNumber=pending`
  - `Tag(BlockTag::Latest)` → implicit (no query param)
  - `Tag(BlockTag::L1Accepted)` → `ConversionError` (the feeder gateway has no `l1_accepted` concept)

  This preserves the exact behavior the previous `TryFrom` had, where `L1Accepted` was unrepresentable.
- Drop the now-unnecessary `.try_into()?` block-id conversions in the `Provider` impl.

## Testing

- `cargo check -p starknet-rust-providers`
- `cargo test -p starknet-rust-providers --lib sequencer` — 32 passed, 0 failed
- `cargo clippy -p starknet-rust-providers` — clean
- `cargo fmt --check` — clean
