### PR TITLE
Replace `chunks_exact` with `as_chunks` in `ByteArray::encode`

### DIFF
--- a/starknet-rust-core-derive/src/lib.rs
+++ b/starknet-rust-core-derive/src/lib.rs
@@ -25,11 +25,11 @@ struct Args {
 impl Args {
     fn merge(&mut self, other: Self) {
         if let Some(core) = other.core {
-            if self.core.is_some() {
-                panic!("starknet attribute `core` defined more than once");
-            } else {
-                self.core = Some(core);
-            }
+            assert!(
+                self.core.is_none(),
+                "starknet attribute `core` defined more than once"
+            );
+            self.core = Some(core);
         }
     }
 }

--- a/starknet-rust-core/src/types/byte_array.rs
+++ b/starknet-rust-core/src/types/byte_array.rs
@@ -59,12 +59,11 @@ impl TryFrom<ByteArray> for String {
 impl Encode for ByteArray {
     fn encode<W: FeltWriter>(&self, writer: &mut W) -> Result<(), CodecError> {
         writer.write((self.len() / BYTES_PER_SLOT).into());
-        let mut chunks_iter = self.0.chunks_exact(BYTES_PER_SLOT);
-        for full_slot in chunks_iter.by_ref() {
+        let (full_slots, last_chunk) = self.0.as_chunks::<BYTES_PER_SLOT>();
+        for full_slot in full_slots {
             writer.write(Felt::from_bytes_be_slice(full_slot));
         }
 
-        let last_chunk = chunks_iter.remainder();
         writer.write(Felt::from_bytes_be_slice(last_chunk));
         writer.write(last_chunk.len().into());
 


### PR DESCRIPTION
## Problem

The nightly `Run Clippy` CI job (`.github/workflows/lint.yaml`, `cargo clippy --all --all-targets -- -D warnings`) is currently failing on `master` — and therefore on every PR — because a recent nightly clippy promoted the `chunks_exact_to_as_chunks` lint, which fires on `ByteArray::encode`:

```
error: using `chunks_exact` with a constant chunk size
  --> starknet-rust-core/src/types/byte_array.rs:62:38
   = note: `-D clippy::chunks-exact-to-as-chunks` implied by `-D warnings`
```

## Change

Use the const-generic `as_chunks::<BYTES_PER_SLOT>()`, which returns the full slots and the trailing remainder directly, instead of `chunks_exact(BYTES_PER_SLOT)` + `.remainder()`. `BYTES_PER_SLOT` is a non-zero constant, and `slice::as_chunks` is stable, so this compiles on both stable and nightly.

Behavior is unchanged.

## Testing

- `cargo +nightly clippy --all --all-targets -- -D warnings <allow-list from CI>` — exits 0, no warnings.
- `cargo test -p starknet-rust-core byte_array` — the encode/decode roundtrip test passes.
- `cargo check` on stable — compiles.