### PR TITLE
Fix `status` type in `NoTraceAvailableErrorData`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Cairo 0 hinted class hash computation for pre-0.10 artifacts: `patch_legacy_cairo_type` is now idempotent (previously double-spaced strings already containing `" : "`), legacy spacing is applied to `references[*].value` entries, and `abi: null` is preserved through the hinted-hash payload ([#148]).
+- `NoTraceAvailableErrorData::status` is now of type `NoTraceAvailableStatus` instead of `SequencerTransactionStatus` ([#157]).
 
 ## [0.19.1] - 2026-05-18
 

--- a/starknet-rust-core/src/types/codegen.rs
+++ b/starknet-rust-core/src/types/codegen.rs
@@ -5,7 +5,7 @@
 //     https://github.com/software-mansion-labs/starknet-jsonrpc-codegen
 
 // Code generated with version:
-//     https://github.com/software-mansion-labs/starknet-jsonrpc-codegen#8333fdcee9ae73bc5546c3d2049bbff938d62b3a
+//     https://github.com/software-mansion-labs/starknet-jsonrpc-codegen#97fc1c18981f4e5d017524edb3b3010c2e2bca12
 
 // These types are ignored from code generation. Implement them manually:
 // - `RECEIPT_BLOCK`
@@ -47,11 +47,12 @@ use serde_with::serde_as;
 use crate::serde::byte_array::base64;
 
 use super::{
+    alloc,
+    serde_impls::{MerkleNodeMap, NumAsHex, OwnedContractExecutionError},
     AddressFilter, BlockId, BroadcastedTransaction, ConfirmedBlockId, ContractExecutionError,
     EthAddress, ExecuteInvocation, ExecutionResult, Felt, Hash256, LegacyContractAbiEntry,
     MerkleNode, ReceiptBlock, Transaction, TransactionContent, TransactionReceipt,
-    TransactionStatus, TransactionTrace, UfeHex, alloc,
-    serde_impls::{MerkleNodeMap, NumAsHex, OwnedContractExecutionError},
+    TransactionStatus, TransactionTrace, UfeHex,
 };
 
 #[cfg(target_has_atomic = "ptr")]
@@ -1816,7 +1817,18 @@ pub struct NewTransactionStatus {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "no_unknown_fields", serde(deny_unknown_fields))]
 pub struct NoTraceAvailableErrorData {
-    pub status: SequencerTransactionStatus,
+    pub status: NoTraceAvailableStatus,
+}
+
+/// No trace available status.
+///
+/// Transaction status explaining why the trace is not available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NoTraceAvailableStatus {
+    #[serde(rename = "RECEIVED")]
+    Received,
+    #[serde(rename = "REJECTED")]
+    Rejected,
 }
 
 /// Nonce update.

--- a/starknet-rust-core/src/types/codegen.rs
+++ b/starknet-rust-core/src/types/codegen.rs
@@ -47,12 +47,11 @@ use serde_with::serde_as;
 use crate::serde::byte_array::base64;
 
 use super::{
-    alloc,
-    serde_impls::{MerkleNodeMap, NumAsHex, OwnedContractExecutionError},
     AddressFilter, BlockId, BroadcastedTransaction, ConfirmedBlockId, ContractExecutionError,
     EthAddress, ExecuteInvocation, ExecutionResult, Felt, Hash256, LegacyContractAbiEntry,
     MerkleNode, ReceiptBlock, Transaction, TransactionContent, TransactionReceipt,
-    TransactionStatus, TransactionTrace, UfeHex,
+    TransactionStatus, TransactionTrace, UfeHex, alloc,
+    serde_impls::{MerkleNodeMap, NumAsHex, OwnedContractExecutionError},
 };
 
 #[cfg(target_has_atomic = "ptr")]


### PR DESCRIPTION
Closes #

## Introduced changes

Change `NoTraceAvailableErrorData::status` type to `NoTraceAvailableStatus`

## Checklist

- [ ] Linked relevant issue
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
