### PR TITLE
fix: accept spec-valid null/string JSON-RPC response ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- JSON-RPC responses with a null or non-numeric `id`, which some servers return for errors raised before the request id is read, now deserialize instead of failing, so the server's error message is surfaced rather than a generic deserialization error ([#159]).
 - Cairo 0 hinted class hash computation for pre-0.10 artifacts: `patch_legacy_cairo_type` is now idempotent (previously double-spaced strings already containing `" : "`), legacy spacing is applied to `references[*].value` entries, and `abi: null` is preserved through the hinted-hash payload ([#148]).
 
 ## [0.19.1] - 2026-05-18
@@ -91,3 +92,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#125]: https://github.com/software-mansion/starknet-rust/pull/125
 [#148]: https://github.com/software-mansion/starknet-rust/pull/148
 [#154]: https://github.com/software-mansion/starknet-rust/pull/154
+[#159]: https://github.com/software-mansion/starknet-rust/pull/159

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#125]: https://github.com/software-mansion/starknet-rust/pull/125
 [#148]: https://github.com/software-mansion/starknet-rust/pull/148
 [#154]: https://github.com/software-mansion/starknet-rust/pull/154
-[#157]: https://github.com/software-mansion/starknet-rust/pull/157
 [#159]: https://github.com/software-mansion/starknet-rust/pull/159
-[#160]: https://github.com/software-mansion/starknet-rust/pull/160

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Breaking:** Removed the redundant sequencer-specific `BlockId` in `starknet-rust-providers`. The sequencer gateway provider now uses the canonical `starknet_rust_core::types::BlockId` throughout ([#154]).
 - **Breaking:** `LegacyContractClass.abi` type changed from `Vec<RawLegacyAbiEntry>` to `Option<Vec<RawLegacyAbiEntry>>` to preserve the `abi: null` vs `abi: []` distinction when computing Cairo 0 hinted class hashes ([#148]).
+- **Breaking:** `JsonRpcResponse`'s response `id` changed from `u64` to `Option<u64>`. A null or non-numeric `id`, which some servers return for errors raised before the request id is read, now deserializes to `None` and surfaces the server's error message instead of failing with a generic deserialization error ([#159]).
 
 ### Fixed
 
-- JSON-RPC responses with a null or non-numeric `id`, which some servers return for errors raised before the request id is read, now deserialize instead of failing, so the server's error message is surfaced rather than a generic deserialization error ([#159]).
 - Cairo 0 hinted class hash computation for pre-0.10 artifacts: `patch_legacy_cairo_type` is now idempotent (previously double-spaced strings already containing `" : "`), legacy spacing is applied to `references[*].value` entries, and `abi: null` is preserved through the hinted-hash payload ([#148]).
 
 ## [0.19.1] - 2026-05-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** Removed the redundant sequencer-specific `BlockId` in `starknet-rust-providers`. The sequencer gateway provider now uses the canonical `starknet_rust_core::types::BlockId` throughout ([#154]).
 - **Breaking:** `LegacyContractClass.abi` type changed from `Vec<RawLegacyAbiEntry>` to `Option<Vec<RawLegacyAbiEntry>>` to preserve the `abi: null` vs `abi: []` distinction when computing Cairo 0 hinted class hashes ([#148]).
 - `StarknetError` display messages now use the JSON-RPC error message instead of the Rust variant name, and string error data is formatted without debug quotes ([#160]).
-- **Breaking:** `JsonRpcResponse`'s response `id` changed from `u64` to `Option<u64>`. A null or non-numeric `id`, which some servers return for errors raised before the request id is read, now deserializes to `None` and surfaces the server's error message instead of failing with a generic deserialization error ([#159]).
+- **Breaking:** `JsonRpcResponse`'s response `id` changed from `u64` to `Option<u64>`. A `null` or string `id`, which some servers return for errors raised before the request id is read, now deserializes to `None` and surfaces the server's error message instead of failing with a generic deserialization error ([#159]).
 
 ### Fixed
 

--- a/starknet-rust-providers/src/jsonrpc/mod.rs
+++ b/starknet-rust-providers/src/jsonrpc/mod.rs
@@ -246,48 +246,40 @@ pub struct JsonRpcError {
     pub data: Option<serde_json::Value>,
 }
 
-/// A JSON-RPC id: a string or a number per JSON-RPC 2.0. A response id is `null`
-/// when the server could not determine the request id, represented here as `None`.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-#[serde(untagged)]
-pub enum JsonRpcId {
-    /// Numeric id.
-    Number(u64),
-    /// String id.
-    String(String),
-}
-
-impl JsonRpcId {
-    /// Returns the numeric id if this is a [`JsonRpcId::Number`], otherwise `None`.
-    ///
-    /// This client only assigns numeric request ids, so response correlation relies on
-    /// this to recover the id and ignores non-numeric (string / null) ids.
-    pub const fn as_u64(&self) -> Option<u64> {
-        match self {
-            Self::Number(id) => Some(*id),
-            Self::String(_) => None,
-        }
-    }
-}
-
 /// JSON-RPC response returned from a server.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 pub enum JsonRpcResponse<T> {
     /// Successful response.
     Success {
-        /// Same id as the corresponding request; `None` when the server sent null.
-        id: Option<JsonRpcId>,
+        /// Same id as the corresponding request. `None` when the server sent a null or
+        /// non-numeric id (e.g. a null id on an error raised before the request was read).
+        #[serde(default, deserialize_with = "deserialize_response_id")]
+        id: Option<u64>,
         /// Response data.
         result: T,
     },
     /// Unsuccessful response.
     Error {
-        /// Same id as the corresponding request; `None` when the server sent null.
-        id: Option<JsonRpcId>,
+        /// Same id as the corresponding request. `None` when the server sent a null or
+        /// non-numeric id (e.g. a null id on an error raised before the request was read).
+        #[serde(default, deserialize_with = "deserialize_response_id")]
+        id: Option<u64>,
         /// Error details.
         error: JsonRpcError,
     },
+}
+
+/// Deserializes a JSON-RPC response `id` into `Option<u64>`.
+///
+/// Per JSON-RPC 2.0 an `id` may be a number, a string, or null. This client only ever
+/// assigns numeric request ids, so a numeric id is recovered and any other shape (string
+/// or null) maps to `None` instead of failing the whole response.
+fn deserialize_response_id<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(serde_json::Value::deserialize(deserializer)?.as_u64())
 }
 
 /// Failures trying to parse a [`JsonRpcError`] into [`StarknetError`].
@@ -1758,20 +1750,21 @@ mod tests {
     }
 
     #[test]
-    fn deserializes_string_and_numeric_ids() {
+    fn deserializes_numeric_and_non_numeric_ids() {
+        // A numeric id is recovered.
         let numeric: JsonRpcResponse<Value> =
             serde_json::from_str(r#"{"jsonrpc":"2.0","id":7,"result":"0x1"}"#).unwrap();
         match numeric {
-            JsonRpcResponse::Success { id, .. } => assert_eq!(id, Some(JsonRpcId::Number(7))),
+            JsonRpcResponse::Success { id, .. } => assert_eq!(id, Some(7)),
             JsonRpcResponse::Error { .. } => panic!("expected Success variant"),
         }
 
+        // A string id is never one this client assigned, so it maps to `None` rather
+        // than failing to deserialize.
         let string: JsonRpcResponse<Value> =
             serde_json::from_str(r#"{"jsonrpc":"2.0","id":"abc","result":"0x1"}"#).unwrap();
         match string {
-            JsonRpcResponse::Success { id, .. } => {
-                assert_eq!(id, Some(JsonRpcId::String("abc".to_owned())));
-            }
+            JsonRpcResponse::Success { id, .. } => assert_eq!(id, None),
             JsonRpcResponse::Error { .. } => panic!("expected Success variant"),
         }
     }

--- a/starknet-rust-providers/src/jsonrpc/mod.rs
+++ b/starknet-rust-providers/src/jsonrpc/mod.rs
@@ -246,21 +246,45 @@ pub struct JsonRpcError {
     pub data: Option<serde_json::Value>,
 }
 
+/// A JSON-RPC id: a string or a number per JSON-RPC 2.0. A response id is `null`
+/// when the server could not determine the request id, represented here as `None`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(untagged)]
+pub enum JsonRpcId {
+    /// Numeric id.
+    Number(u64),
+    /// String id.
+    String(String),
+}
+
+impl JsonRpcId {
+    /// Returns the numeric id if this is a [`JsonRpcId::Number`], otherwise `None`.
+    ///
+    /// This client only assigns numeric request ids, so response correlation relies on
+    /// this to recover the id and ignores non-numeric (string / null) ids.
+    pub const fn as_u64(&self) -> Option<u64> {
+        match self {
+            Self::Number(id) => Some(*id),
+            Self::String(_) => None,
+        }
+    }
+}
+
 /// JSON-RPC response returned from a server.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 pub enum JsonRpcResponse<T> {
     /// Successful response.
     Success {
-        /// Same ID as the corresponding request.
-        id: u64,
+        /// Same id as the corresponding request; `None` when the server sent null.
+        id: Option<JsonRpcId>,
         /// Response data.
         result: T,
     },
     /// Unsuccessful response.
     Error {
-        /// Same ID as the corresponding request.
-        id: u64,
+        /// Same id as the corresponding request; `None` when the server sent null.
+        id: Option<JsonRpcId>,
         /// Error details.
         error: JsonRpcError,
     },
@@ -1714,6 +1738,42 @@ mod tests {
 
     fn as_object(value: &Value) -> &serde_json::Map<String, Value> {
         value.as_object().expect("object params")
+    }
+
+    #[test]
+    fn deserializes_error_response_with_null_id() {
+        // A spec-compliant JSON-RPC error can carry `"id": null` (e.g. when the server
+        // rejects the request before it can read the id). It must still deserialize, and
+        // the error must be surfaced rather than dropped.
+        let body = r#"{"jsonrpc":"2.0","id":null,"error":{"code":-32000,"message":"gone"}}"#;
+        let parsed: JsonRpcResponse<Value> = serde_json::from_str(body).unwrap();
+        match parsed {
+            JsonRpcResponse::Error { id, error } => {
+                assert_eq!(id, None);
+                assert_eq!(error.code, -32000);
+                assert_eq!(error.message, "gone");
+            }
+            JsonRpcResponse::Success { .. } => panic!("expected Error variant"),
+        }
+    }
+
+    #[test]
+    fn deserializes_string_and_numeric_ids() {
+        let numeric: JsonRpcResponse<Value> =
+            serde_json::from_str(r#"{"jsonrpc":"2.0","id":7,"result":"0x1"}"#).unwrap();
+        match numeric {
+            JsonRpcResponse::Success { id, .. } => assert_eq!(id, Some(JsonRpcId::Number(7))),
+            JsonRpcResponse::Error { .. } => panic!("expected Success variant"),
+        }
+
+        let string: JsonRpcResponse<Value> =
+            serde_json::from_str(r#"{"jsonrpc":"2.0","id":"abc","result":"0x1"}"#).unwrap();
+        match string {
+            JsonRpcResponse::Success { id, .. } => {
+                assert_eq!(id, Some(JsonRpcId::String("abc".to_owned())));
+            }
+            JsonRpcResponse::Error { .. } => panic!("expected Success variant"),
+        }
     }
 
     #[test]

--- a/starknet-rust-providers/src/jsonrpc/mod.rs
+++ b/starknet-rust-providers/src/jsonrpc/mod.rs
@@ -253,7 +253,7 @@ pub enum JsonRpcResponse<T> {
     /// Successful response.
     Success {
         /// Same id as the corresponding request. `None` when the server sent a null or
-        /// non-numeric id (e.g. a null id on an error raised before the request was read).
+        /// invalid numeric id (e.g. a null id on an error raised before the request was read).
         #[serde(default, deserialize_with = "deserialize_response_id")]
         id: Option<u64>,
         /// Response data.
@@ -262,7 +262,7 @@ pub enum JsonRpcResponse<T> {
     /// Unsuccessful response.
     Error {
         /// Same id as the corresponding request. `None` when the server sent a null or
-        /// non-numeric id (e.g. a null id on an error raised before the request was read).
+        /// invalid numeric id (e.g. a null id on an error raised before the request was read).
         #[serde(default, deserialize_with = "deserialize_response_id")]
         id: Option<u64>,
         /// Error details.

--- a/starknet-rust-providers/src/jsonrpc/transports/http.rs
+++ b/starknet-rust-providers/src/jsonrpc/transports/http.rs
@@ -5,7 +5,7 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use crate::{
     ProviderRequestData,
-    jsonrpc::{JsonRpcId, JsonRpcMethod, JsonRpcResponse, transports::JsonRpcTransport},
+    jsonrpc::{JsonRpcMethod, JsonRpcResponse, transports::JsonRpcTransport},
 };
 
 /// A [`JsonRpcTransport`] implementation that uses HTTP connections.
@@ -27,6 +27,9 @@ pub enum HttpTransportError {
     /// Unexpected response ID.
     #[error("unexpected response ID: {0}")]
     UnexpectedResponseId(u64),
+    /// Response carried a non-numeric (string or null) id that can't be matched to a request.
+    #[error("response has a non-numeric id")]
+    NonNumericResponseId,
 }
 
 #[derive(Debug, Serialize)]
@@ -165,15 +168,14 @@ impl JsonRpcTransport for HttpTransport {
         // Re-order the responses as servers do not maintain order.
         for response_item in parsed_response {
             let id = match &response_item {
-                JsonRpcResponse::Success { id, .. } | JsonRpcResponse::Error { id, .. } => {
-                    match id {
-                        Some(JsonRpcId::Number(id)) => *id as usize,
-                        // The client only assigns numeric ids to batched requests, so a
-                        // non-numeric id (string or null) can't be correlated to one;
-                        // treat it as out of range so the check below rejects it.
-                        _ => request_count,
-                    }
-                }
+                JsonRpcResponse::Success { id, .. } | JsonRpcResponse::Error { id, .. } => id,
+            };
+
+            // This client assigns a numeric id to every batched request, so a response
+            // with a non-numeric (string or null) id can't be correlated to one.
+            let id = match id {
+                Some(id) => *id as usize,
+                None => return Err(HttpTransportError::NonNumericResponseId),
             };
 
             if id >= request_count {

--- a/starknet-rust-providers/src/jsonrpc/transports/http.rs
+++ b/starknet-rust-providers/src/jsonrpc/transports/http.rs
@@ -5,7 +5,7 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use crate::{
     ProviderRequestData,
-    jsonrpc::{JsonRpcMethod, JsonRpcResponse, transports::JsonRpcTransport},
+    jsonrpc::{JsonRpcId, JsonRpcMethod, JsonRpcResponse, transports::JsonRpcTransport},
 };
 
 /// A [`JsonRpcTransport`] implementation that uses HTTP connections.
@@ -166,7 +166,13 @@ impl JsonRpcTransport for HttpTransport {
         for response_item in parsed_response {
             let id = match &response_item {
                 JsonRpcResponse::Success { id, .. } | JsonRpcResponse::Error { id, .. } => {
-                    *id as usize
+                    match id {
+                        Some(JsonRpcId::Number(id)) => *id as usize,
+                        // The client only assigns numeric ids to batched requests, so a
+                        // non-numeric id (string or null) can't be correlated to one;
+                        // treat it as out of range so the check below rejects it.
+                        _ => request_count,
+                    }
                 }
             };
 

--- a/starknet-rust-providers/src/jsonrpc/transports/http.rs
+++ b/starknet-rust-providers/src/jsonrpc/transports/http.rs
@@ -27,7 +27,7 @@ pub enum HttpTransportError {
     /// Unexpected response ID.
     #[error("unexpected response ID: {0}")]
     UnexpectedResponseId(u64),
-    /// Response carried a non-numeric (string or null) id that can't be matched to a request.
+    /// Response carried not a valid numeric id that can't be matched to a request.
     #[error("response has a non-numeric id")]
     NonNumericResponseId,
 }

--- a/starknet-rust-providers/src/jsonrpc/transports/http.rs
+++ b/starknet-rust-providers/src/jsonrpc/transports/http.rs
@@ -27,9 +27,9 @@ pub enum HttpTransportError {
     /// Unexpected response ID.
     #[error("unexpected response ID: {0}")]
     UnexpectedResponseId(u64),
-    /// Response carried not a valid numeric id that can't be matched to a request.
-    #[error("response has a non-numeric id")]
-    NonNumericResponseId,
+    /// Response carried an invalid numeric id that can't be matched to a request.
+    #[error("response has an invalid numeric id")]
+    InvalidNumericResponseId,
 }
 
 #[derive(Debug, Serialize)]
@@ -172,10 +172,10 @@ impl JsonRpcTransport for HttpTransport {
             };
 
             // This client assigns a numeric id to every batched request, so a response
-            // with a non-numeric (string or null) id can't be correlated to one.
+            // with an invalid numeric id can't be correlated to one.
             let id = match id {
                 Some(id) => *id as usize,
-                None => return Err(HttpTransportError::NonNumericResponseId),
+                None => return Err(HttpTransportError::InvalidNumericResponseId),
             };
 
             if id >= request_count {

--- a/starknet-rust-providers/src/jsonrpc/transports/worker.rs
+++ b/starknet-rust-providers/src/jsonrpc/transports/worker.rs
@@ -26,9 +26,9 @@ pub enum WorkersTransportError {
     /// Unexpected response ID.
     #[error("unexpected response ID: {0}")]
     UnexpectedResponseId(u64),
-    /// Response carried not a valid numeric id that can't be matched to a request.
-    #[error("response has a non-numeric id")]
-    NonNumericResponseId,
+    /// Response carried an invalid numeric id that can't be matched to a request.
+    #[error("response has an invalid numeric id")]
+    InvalidNumericResponseId,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -169,10 +169,10 @@ impl JsonRpcTransport for WorkersTransport {
             };
 
             // This client assigns a numeric id to every batched request, so a response
-            // with a non-numeric (string or null) id can't be correlated to one.
+            // with an invalid numeric id can't be correlated to one.
             let id = match id {
                 Some(id) => *id as usize,
-                None => return Err(Self::Error::NonNumericResponseId),
+                None => return Err(Self::Error::InvalidNumericResponseId),
             };
 
             if id >= request_count {

--- a/starknet-rust-providers/src/jsonrpc/transports/worker.rs
+++ b/starknet-rust-providers/src/jsonrpc/transports/worker.rs
@@ -26,6 +26,9 @@ pub enum WorkersTransportError {
     /// Unexpected response ID.
     #[error("unexpected response ID: {0}")]
     UnexpectedResponseId(u64),
+    /// Response carried a non-numeric (string or null) id that can't be matched to a request.
+    #[error("response has a non-numeric id")]
+    NonNumericResponseId,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -162,9 +165,14 @@ impl JsonRpcTransport for WorkersTransport {
         // Re-order the responses as servers do not maintain order.
         for response_item in parsed_response {
             let id = match &response_item {
-                JsonRpcResponse::Success { id, .. } | JsonRpcResponse::Error { id, .. } => {
-                    *id as usize
-                }
+                JsonRpcResponse::Success { id, .. } | JsonRpcResponse::Error { id, .. } => id,
+            };
+
+            // This client assigns a numeric id to every batched request, so a response
+            // with a non-numeric (string or null) id can't be correlated to one.
+            let id = match id {
+                Some(id) => *id as usize,
+                None => return Err(Self::Error::NonNumericResponseId),
             };
 
             if id >= request_count {

--- a/starknet-rust-providers/src/jsonrpc/transports/worker.rs
+++ b/starknet-rust-providers/src/jsonrpc/transports/worker.rs
@@ -26,7 +26,7 @@ pub enum WorkersTransportError {
     /// Unexpected response ID.
     #[error("unexpected response ID: {0}")]
     UnexpectedResponseId(u64),
-    /// Response carried a non-numeric (string or null) id that can't be matched to a request.
+    /// Response carried not a valid numeric id that can't be matched to a request.
     #[error("response has a non-numeric id")]
     NonNumericResponseId,
 }

--- a/starknet-rust-tokio-tungstenite/src/stream/read.rs
+++ b/starknet-rust-tokio-tungstenite/src/stream/read.rs
@@ -189,10 +189,11 @@ impl StreamReadDriver {
                         }
                     }
                     StreamUpdateOrResponse::Response(JsonRpcResponse::Success { id, result }) => {
+                        let id = id.and_then(|i| i.as_u64());
                         match result {
                             SubscriptionIdOrBool::SubscriptionId(subscription_id) => {
                                 // Response for subscribe requests
-                                match self.pending_subscriptions.remove(&id) {
+                                match id.and_then(|id| self.pending_subscriptions.remove(&id)) {
                                     Some(pending) => {
                                         if matches!(
                                             pending.result.send(SubscriptionResult::Success {
@@ -220,7 +221,7 @@ impl StreamReadDriver {
                             }
                             SubscriptionIdOrBool::Bool(success) => {
                                 // Response for unsubscribe requests
-                                match self.pending_unsubscriptions.remove(&id) {
+                                match id.and_then(|id| self.pending_unsubscriptions.remove(&id)) {
                                     Some(pending) => {
                                         // Remove the subscription from internal registry on a best-
                                         // effort basis. It's fine if it doesn't exist.
@@ -242,13 +243,17 @@ impl StreamReadDriver {
                         }
                     }
                     StreamUpdateOrResponse::Response(JsonRpcResponse::Error { id, error }) => {
-                        if let Some(pending_sub) = self.pending_subscriptions.remove(&id) {
+                        let id = id.and_then(|i| i.as_u64());
+                        if let Some(pending_sub) =
+                            id.and_then(|id| self.pending_subscriptions.remove(&id))
+                        {
                             // This failing means the caller gave up on waiting. Ignoring failure is
                             // fine as the subscription didn't succeed anyway.
                             let _ = pending_sub
                                 .result
                                 .send(SubscriptionResult::JsonRpcError(error));
-                        } else if let Some(pending_unsub) = self.pending_unsubscriptions.remove(&id)
+                        } else if let Some(pending_unsub) =
+                            id.and_then(|id| self.pending_unsubscriptions.remove(&id))
                         {
                             // This failing means the caller gave up on waiting. Ignoring failure is
                             // fine as this usually indicates that the subscription doesn't exist.

--- a/starknet-rust-tokio-tungstenite/src/stream/read.rs
+++ b/starknet-rust-tokio-tungstenite/src/stream/read.rs
@@ -189,7 +189,6 @@ impl StreamReadDriver {
                         }
                     }
                     StreamUpdateOrResponse::Response(JsonRpcResponse::Success { id, result }) => {
-                        let id = id.and_then(|i| i.as_u64());
                         match result {
                             SubscriptionIdOrBool::SubscriptionId(subscription_id) => {
                                 // Response for subscribe requests
@@ -243,7 +242,6 @@ impl StreamReadDriver {
                         }
                     }
                     StreamUpdateOrResponse::Response(JsonRpcResponse::Error { id, error }) => {
-                        let id = id.and_then(|i| i.as_u64());
                         if let Some(pending_sub) =
                             id.and_then(|id| self.pending_subscriptions.remove(&id))
                         {


### PR DESCRIPTION
Fixes #158.

## Problem

`JsonRpcResponse` typed the response `id` as `u64`, but JSON-RPC 2.0 allows an id to be a
string, a number, or **null** (a server sends `null` when it can't determine the request id,
e.g. parse / server errors). An error response with `"id": null` failed to deserialize the
`#[serde(untagged)]` enum, so the server's `error.message` was discarded and callers only saw:

```
data did not match any variant of untagged enum JsonRpcResponse
```

## Change

- Add a `JsonRpcId` enum (`Number(u64) | String(String)`) and type both `JsonRpcResponse`
  variants' `id` as `Option<JsonRpcId>` (`null → None`).
- The HTTP batch transport correlates responses to requests by numeric id; it now extracts
  `JsonRpcId::Number` and treats a non-numeric id as out of range (routed through the existing
  `UnexpectedResponseId` check). No new error variant.
- Regression tests for null / string / numeric ids.

Note: this changes the public `id` field type from `u64` to `Option<JsonRpcId>`.

## Verification

- `cargo build -p starknet-rust-providers` ✓
- `cargo test -p starknet-rust-providers --lib` → 39 passed, 0 failed (incl. 2 new tests) ✓
- `cargo fmt --check` ✓ · `cargo clippy` ✓
