### PR TITLE
Improve `StarknetError` display messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cairo 0 hinted class hash computation for pre-0.10 artifacts: `patch_legacy_cairo_type` is now idempotent (previously double-spaced strings already containing `" : "`), legacy spacing is applied to `references[*].value` entries, and `abi: null` is preserved through the hinted-hash payload ([#148]).
 - `NoTraceAvailableErrorData::status` is now of type `NoTraceAvailableStatus` instead of `SequencerTransactionStatus` ([#157]).
-- `StarknetError` display messages now use the JSON-RPC error message instead of the Rust variant name, and string error data is formatted without debug quotes.
+- `StarknetError` display messages now use the JSON-RPC error message instead of the Rust variant name, and string error data is formatted without debug quotes ([#160]).
 
 ## [0.19.1] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cairo 0 hinted class hash computation for pre-0.10 artifacts: `patch_legacy_cairo_type` is now idempotent (previously double-spaced strings already containing `" : "`), legacy spacing is applied to `references[*].value` entries, and `abi: null` is preserved through the hinted-hash payload ([#148]).
 - `NoTraceAvailableErrorData::status` is now of type `NoTraceAvailableStatus` instead of `SequencerTransactionStatus` ([#157]).
+- `StarknetError` display messages now use the JSON-RPC error message instead of the Rust variant name, and string error data is formatted without debug quotes.
 
 ## [0.19.1] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Breaking:** Removed the redundant sequencer-specific `BlockId` in `starknet-rust-providers`. The sequencer gateway provider now uses the canonical `starknet_rust_core::types::BlockId` throughout ([#154]).
 - **Breaking:** `LegacyContractClass.abi` type changed from `Vec<RawLegacyAbiEntry>` to `Option<Vec<RawLegacyAbiEntry>>` to preserve the `abi: null` vs `abi: []` distinction when computing Cairo 0 hinted class hashes ([#148]).
+- `StarknetError` display messages now use the JSON-RPC error message instead of the Rust variant name, and string error data is formatted without debug quotes ([#160]).
 
 ### Fixed
 
 - Cairo 0 hinted class hash computation for pre-0.10 artifacts: `patch_legacy_cairo_type` is now idempotent (previously double-spaced strings already containing `" : "`), legacy spacing is applied to `references[*].value` entries, and `abi: null` is preserved through the hinted-hash payload ([#148]).
 - `NoTraceAvailableErrorData::status` is now of type `NoTraceAvailableStatus` instead of `SequencerTransactionStatus` ([#157]).
-- `StarknetError` display messages now use the JSON-RPC error message instead of the Rust variant name, and string error data is formatted without debug quotes ([#160]).
 
 ## [0.19.1] - 2026-05-18
 

--- a/starknet-rust-core/src/types/codegen.rs
+++ b/starknet-rust-core/src/types/codegen.rs
@@ -5,7 +5,7 @@
 //     https://github.com/software-mansion-labs/starknet-jsonrpc-codegen
 
 // Code generated with version:
-//     https://github.com/software-mansion-labs/starknet-jsonrpc-codegen#97fc1c18981f4e5d017524edb3b3010c2e2bca12
+//     https://github.com/software-mansion-labs/starknet-jsonrpc-codegen#4a887f270cca7ec2a433ffbfcee8cc10a6d0709d
 
 // These types are ignored from code generation. Implement them manually:
 // - `RECEIPT_BLOCK`
@@ -2244,42 +2244,40 @@ impl std::error::Error for StarknetError {}
 impl core::fmt::Display for StarknetError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::FailedToReceiveTransaction => write!(f, "FailedToReceiveTransaction"),
-            Self::ContractNotFound => write!(f, "ContractNotFound"),
-            Self::EntrypointNotFound => write!(f, "EntrypointNotFound"),
-            Self::BlockNotFound => write!(f, "BlockNotFound"),
-            Self::InvalidTransactionIndex => write!(f, "InvalidTransactionIndex"),
-            Self::ClassHashNotFound => write!(f, "ClassHashNotFound"),
-            Self::TransactionHashNotFound => write!(f, "TransactionHashNotFound"),
-            Self::PageSizeTooBig => write!(f, "PageSizeTooBig"),
-            Self::NoBlocks => write!(f, "NoBlocks"),
-            Self::InvalidContinuationToken => write!(f, "InvalidContinuationToken"),
-            Self::TooManyKeysInFilter => write!(f, "TooManyKeysInFilter"),
-            Self::ContractError(e) => write!(f, "ContractError: {e:?}"),
-            Self::TransactionExecutionError(e) => write!(f, "TransactionExecutionError: {e:?}"),
-            Self::StorageProofNotSupported => write!(f, "StorageProofNotSupported"),
-            Self::ClassAlreadyDeclared => write!(f, "ClassAlreadyDeclared"),
-            Self::InvalidTransactionNonce(e) => write!(f, "InvalidTransactionNonce: {e:?}"),
-            Self::InsufficientResourcesForValidate => write!(f, "InsufficientResourcesForValidate"),
-            Self::InsufficientAccountBalance => write!(f, "InsufficientAccountBalance"),
-            Self::ValidationFailure(e) => write!(f, "ValidationFailure: {e:?}"),
-            Self::CompilationFailed(e) => write!(f, "CompilationFailed: {e:?}"),
-            Self::ContractClassSizeIsTooLarge => write!(f, "ContractClassSizeIsTooLarge"),
-            Self::NonAccount => write!(f, "NonAccount"),
-            Self::DuplicateTx => write!(f, "DuplicateTx"),
-            Self::CompiledClassHashMismatch => write!(f, "CompiledClassHashMismatch"),
-            Self::UnsupportedTxVersion => write!(f, "UnsupportedTxVersion"),
-            Self::UnsupportedContractClassVersion => write!(f, "UnsupportedContractClassVersion"),
-            Self::UnexpectedError(e) => write!(f, "UnexpectedError: {e:?}"),
-            Self::ReplacementTransactionUnderpriced => {
-                write!(f, "ReplacementTransactionUnderpriced")
-            }
-            Self::FeeBelowMinimum => write!(f, "FeeBelowMinimum"),
-            Self::InvalidProof => write!(f, "InvalidProof"),
-            Self::NoTraceAvailable(e) => write!(f, "NoTraceAvailable: {e:?}"),
-            Self::InvalidSubscriptionId => write!(f, "InvalidSubscriptionId"),
-            Self::TooManyAddressesInFilter => write!(f, "TooManyAddressesInFilter"),
-            Self::TooManyBlocksBack => write!(f, "TooManyBlocksBack"),
+            Self::FailedToReceiveTransaction => f.write_str(self.message()),
+            Self::ContractNotFound => f.write_str(self.message()),
+            Self::EntrypointNotFound => f.write_str(self.message()),
+            Self::BlockNotFound => f.write_str(self.message()),
+            Self::InvalidTransactionIndex => f.write_str(self.message()),
+            Self::ClassHashNotFound => f.write_str(self.message()),
+            Self::TransactionHashNotFound => f.write_str(self.message()),
+            Self::PageSizeTooBig => f.write_str(self.message()),
+            Self::NoBlocks => f.write_str(self.message()),
+            Self::InvalidContinuationToken => f.write_str(self.message()),
+            Self::TooManyKeysInFilter => f.write_str(self.message()),
+            Self::ContractError(e) => write!(f, "{}: {e:?}", self.message()),
+            Self::TransactionExecutionError(e) => write!(f, "{}: {e:?}", self.message()),
+            Self::StorageProofNotSupported => f.write_str(self.message()),
+            Self::ClassAlreadyDeclared => f.write_str(self.message()),
+            Self::InvalidTransactionNonce(e) => write!(f, "{}: {e}", self.message()),
+            Self::InsufficientResourcesForValidate => f.write_str(self.message()),
+            Self::InsufficientAccountBalance => f.write_str(self.message()),
+            Self::ValidationFailure(e) => write!(f, "{}: {e}", self.message()),
+            Self::CompilationFailed(e) => write!(f, "{}: {e}", self.message()),
+            Self::ContractClassSizeIsTooLarge => f.write_str(self.message()),
+            Self::NonAccount => f.write_str(self.message()),
+            Self::DuplicateTx => f.write_str(self.message()),
+            Self::CompiledClassHashMismatch => f.write_str(self.message()),
+            Self::UnsupportedTxVersion => f.write_str(self.message()),
+            Self::UnsupportedContractClassVersion => f.write_str(self.message()),
+            Self::UnexpectedError(e) => write!(f, "{}: {e}", self.message()),
+            Self::ReplacementTransactionUnderpriced => f.write_str(self.message()),
+            Self::FeeBelowMinimum => f.write_str(self.message()),
+            Self::InvalidProof => f.write_str(self.message()),
+            Self::NoTraceAvailable(e) => write!(f, "{}: {e:?}", self.message()),
+            Self::InvalidSubscriptionId => f.write_str(self.message()),
+            Self::TooManyAddressesInFilter => f.write_str(self.message()),
+            Self::TooManyBlocksBack => f.write_str(self.message()),
         }
     }
 }

--- a/starknet-rust-core/src/types/codegen.rs
+++ b/starknet-rust-core/src/types/codegen.rs
@@ -5,7 +5,7 @@
 //     https://github.com/software-mansion-labs/starknet-jsonrpc-codegen
 
 // Code generated with version:
-//     https://github.com/software-mansion-labs/starknet-jsonrpc-codegen#4a887f270cca7ec2a433ffbfcee8cc10a6d0709d
+//     https://github.com/software-mansion-labs/starknet-jsonrpc-codegen#9a85772273869ac2b4a9ee6348862223031f8e19
 
 // These types are ignored from code generation. Implement them manually:
 // - `RECEIPT_BLOCK`
@@ -2241,6 +2241,7 @@ pub enum StarknetError {
 #[cfg(feature = "std")]
 impl std::error::Error for StarknetError {}
 
+#[allow(clippy::match_same_arms)]
 impl core::fmt::Display for StarknetError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {

--- a/starknet-rust-core/src/types/codegen.rs
+++ b/starknet-rust-core/src/types/codegen.rs
@@ -5,7 +5,7 @@
 //     https://github.com/software-mansion-labs/starknet-jsonrpc-codegen
 
 // Code generated with version:
-//     https://github.com/software-mansion-labs/starknet-jsonrpc-codegen#4a887f270cca7ec2a433ffbfcee8cc10a6d0709d
+//     https://github.com/software-mansion-labs/starknet-jsonrpc-codegen#773cd8ba6c077eacf6b3241319c95f58857442fe
 
 // These types are ignored from code generation. Implement them manually:
 // - `RECEIPT_BLOCK`
@@ -2241,6 +2241,7 @@ pub enum StarknetError {
 #[cfg(feature = "std")]
 impl std::error::Error for StarknetError {}
 
+#[allow(clippy::match_same_arms)]
 impl core::fmt::Display for StarknetError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {

--- a/starknet-rust-core/src/types/codegen.rs
+++ b/starknet-rust-core/src/types/codegen.rs
@@ -5,7 +5,7 @@
 //     https://github.com/software-mansion-labs/starknet-jsonrpc-codegen
 
 // Code generated with version:
-//     https://github.com/software-mansion-labs/starknet-jsonrpc-codegen#9a85772273869ac2b4a9ee6348862223031f8e19
+//     https://github.com/software-mansion-labs/starknet-jsonrpc-codegen#4a887f270cca7ec2a433ffbfcee8cc10a6d0709d
 
 // These types are ignored from code generation. Implement them manually:
 // - `RECEIPT_BLOCK`
@@ -2241,7 +2241,6 @@ pub enum StarknetError {
 #[cfg(feature = "std")]
 impl std::error::Error for StarknetError {}
 
-#[allow(clippy::match_same_arms)]
 impl core::fmt::Display for StarknetError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {


### PR DESCRIPTION
Closes #

## Introduced changes

`StarknetError` display messages now use the JSON-RPC error message instead of the Rust variant name, and string error data is formatted without debug quotes.

## Checklist

- [ ] Linked relevant issue
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
