### PR TITLE
fix: surface server error when a JSON-RPC batch is rejected as a whole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cairo 0 hinted class hash computation for pre-0.10 artifacts: `patch_legacy_cairo_type` is now idempotent (previously double-spaced strings already containing `" : "`), legacy spacing is applied to `references[*].value` entries, and `abi: null` is preserved through the hinted-hash payload ([#148]).
 - `NoTraceAvailableErrorData::status` is now of type `NoTraceAvailableStatus` instead of `SequencerTransactionStatus` ([#157]).
+- `JsonRpcClient::batch_requests` now surfaces the server's error when a batch is rejected as a whole (returned as a single JSON-RPC error object per the spec, e.g. exceeding the server's batch-size limit) instead of failing with a generic deserialization error ([#163]).
 
 ## [0.19.1] - 2026-05-18
 
@@ -95,3 +96,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#148]: https://github.com/software-mansion/starknet-rust/pull/148
 [#154]: https://github.com/software-mansion/starknet-rust/pull/154
 [#159]: https://github.com/software-mansion/starknet-rust/pull/159
+[#163]: https://github.com/software-mansion/starknet-rust/pull/163

--- a/starknet-rust-providers/src/jsonrpc/mod.rs
+++ b/starknet-rust-providers/src/jsonrpc/mod.rs
@@ -1732,6 +1732,47 @@ mod tests {
         value.as_object().expect("object params")
     }
 
+    #[tokio::test]
+    async fn surfaces_whole_batch_rejection_error() {
+        use crate::{JsonRpcClient, Provider, ProviderRequestData, Url, jsonrpc::HttpTransport};
+        use starknet_rust_core::types::requests::SpecVersionRequest;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        // A server that rejects a batch as a whole replies with a single JSON-RPC error
+        // object (per the spec), e.g. Pathfinder when a batch exceeds its 100-request cap.
+        let body = r#"{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"Parse error","data":{"reason":"array exceeds maximum length 100"}}}"#;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 8192];
+            let _ = socket.read(&mut buf).await;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            let _ = socket.write_all(response.as_bytes()).await;
+        });
+
+        let url = Url::parse(&format!("http://{addr}/")).unwrap();
+        let client = JsonRpcClient::new(HttpTransport::new(url));
+
+        let err = client
+            .batch_requests(&[ProviderRequestData::SpecVersion(SpecVersionRequest)])
+            .await
+            .expect_err("a whole-batch rejection must surface as an error");
+
+        // Before the fix the server's message was replaced by a generic
+        // "expected a sequence" deserialization error; now it is surfaced.
+        let rendered = format!("{err:?}");
+        assert!(
+            rendered.contains("array exceeds maximum length"),
+            "server error was not surfaced: {rendered}"
+        );
+    }
+
     #[test]
     fn deserializes_error_response_with_null_id() {
         // A spec-compliant JSON-RPC error can carry `"id": null` (e.g. when the server

--- a/starknet-rust-providers/src/jsonrpc/transports/http.rs
+++ b/starknet-rust-providers/src/jsonrpc/transports/http.rs
@@ -5,7 +5,7 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use crate::{
     ProviderRequestData,
-    jsonrpc::{JsonRpcMethod, JsonRpcResponse, transports::JsonRpcTransport},
+    jsonrpc::{JsonRpcError, JsonRpcMethod, JsonRpcResponse, transports::JsonRpcTransport},
 };
 
 /// A [`JsonRpcTransport`] implementation that uses HTTP connections.
@@ -30,6 +30,8 @@ pub enum HttpTransportError {
     /// Response carried an invalid numeric id that can't be matched to a request.
     #[error("response has an invalid numeric id")]
     InvalidNumericResponseId,
+    /// The server rejected the batch as a whole and returned a single JSON-RPC error.
+    BatchError(JsonRpcError),
 }
 
 #[derive(Debug, Serialize)]
@@ -160,7 +162,20 @@ impl JsonRpcTransport for HttpTransport {
         trace!("Response from JSON-RPC: {response_body}");
 
         let parsed_response: Vec<JsonRpcResponse<serde_json::Value>> =
-            serde_json::from_str(&response_body).map_err(Self::Error::Json)?;
+            match serde_json::from_str(&response_body) {
+                Ok(parsed) => parsed,
+                Err(err) => {
+                    // A batch rejected as a whole is returned as a single JSON-RPC response
+                    // object (per JSON-RPC 2.0), not an array. Surface its error instead of
+                    // the opaque sequence type-mismatch.
+                    if let Ok(JsonRpcResponse::Error { error, .. }) =
+                        serde_json::from_str::<JsonRpcResponse<serde_json::Value>>(&response_body)
+                    {
+                        return Err(Self::Error::BatchError(error));
+                    }
+                    return Err(Self::Error::Json(err));
+                }
+            };
 
         let mut responses: Vec<Option<JsonRpcResponse<serde_json::Value>>> = vec![];
         responses.resize(request_bodies.len(), None);

--- a/starknet-rust-providers/src/jsonrpc/transports/worker.rs
+++ b/starknet-rust-providers/src/jsonrpc/transports/worker.rs
@@ -4,7 +4,7 @@ use url::Url;
 
 use crate::{
     ProviderRequestData,
-    jsonrpc::{JsonRpcMethod, JsonRpcResponse, transports::JsonRpcTransport},
+    jsonrpc::{JsonRpcError, JsonRpcMethod, JsonRpcResponse, transports::JsonRpcTransport},
 };
 
 /// A [`JsonRpcTransport`] implementation for the Cloudflare Workers environment.
@@ -29,6 +29,8 @@ pub enum WorkersTransportError {
     /// Response carried an invalid numeric id that can't be matched to a request.
     #[error("response has an invalid numeric id")]
     InvalidNumericResponseId,
+    /// The server rejected the batch as a whole and returned a single JSON-RPC error.
+    BatchError(JsonRpcError),
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -157,7 +159,20 @@ impl JsonRpcTransport for WorkersTransport {
         let response_body = response.text().await?;
 
         let parsed_response: Vec<JsonRpcResponse<serde_json::Value>> =
-            serde_json::from_str(&response_body).map_err(Self::Error::Json)?;
+            match serde_json::from_str(&response_body) {
+                Ok(parsed) => parsed,
+                Err(err) => {
+                    // A batch rejected as a whole is returned as a single JSON-RPC response
+                    // object (per JSON-RPC 2.0), not an array. Surface its error instead of
+                    // the opaque sequence type-mismatch.
+                    if let Ok(JsonRpcResponse::Error { error, .. }) =
+                        serde_json::from_str::<JsonRpcResponse<serde_json::Value>>(&response_body)
+                    {
+                        return Err(Self::Error::BatchError(error));
+                    }
+                    return Err(Self::Error::Json(err));
+                }
+            };
 
         let mut responses: Vec<Option<JsonRpcResponse<serde_json::Value>>> = vec![];
         responses.resize(request_bodies.len(), None);


### PR DESCRIPTION
Fixes #152.

When a server rejects a JSON-RPC batch as a whole, it replies with a single error object (valid per JSON-RPC 2.0), not an array. For example, Pathfinder returns a single `-32700` error when a batch exceeds its 100-request cap. `send_requests` deserialized the body only as an array, so it failed with a generic `invalid type: map, expected a sequence` and the server's real message was discarded.

`send_requests` (HTTP and Workers transports) now falls back to parsing the body as a single `JsonRpcResponse` when the array parse fails; if it is an error, the server's error is surfaced through a new `BatchError(JsonRpcError)` transport error variant.
